### PR TITLE
Update nexus behaviors.. 

### DIFF
--- a/zero/zones/nexus/DuelBehavior.cpp
+++ b/zero/zones/nexus/DuelBehavior.cpp
@@ -138,21 +138,22 @@ std::unique_ptr<behavior::BehaviorNode> DuelBehavior::CreateTree(behavior::Execu
 
   const Vector2f center(512, 512);
 
-   // Used for target prio
-  constexpr float kLowEnergyThreshold = 700.0f;         // Energy threshold to prio targets
-  constexpr float kLowEnergyDistanceThreshold = 20.0f;  // Distance threshold for prio targets
+// Pursue targets below these thresholds, otherwise attack from distance
+  constexpr float kLowEnergyThreshold = 700.0f;         // Energy threshold
+  constexpr float kLowEnergyDistanceThreshold = 18.0f;  // Distance threshold
+  constexpr u32 kRushRepelThreshold = 1;  // If we don't have this many reps dont rush targets (in testing)
 
-  // Rush threshold / dodge thresholds
-  constexpr float kLowEnergyRushThreshold = 350.0f;  // If within rush distance and below this threshold
-  constexpr float kRushDistanceThreshold = 10.0f;    // If below rush energy threshold and this distance
-  constexpr u32 kRushRepelThreshold = 1;             // If we don't have this many reps dont rush targets
+  // Stop attempting to dodge when target is below these thresholds
+  constexpr float kLowEnergyRushThreshold = 300.0f;  // Energy threshold
+  constexpr float kRushDistanceThreshold = 8.0f;     // Distance threshold
 
-  // This is how far away to check for enemies that are rushing at us with low energy.
-  // We will stop dodging and try to finish them off if they are within this distance and low energy.
-  constexpr float kNearbyEnemyThreshold = 10.0f;
+  // Other dodge
+  constexpr float kDodgeVelocityThreshold = 10.0f;
+  constexpr float kDodgeRangeSlow = 20.0f;
+  constexpr float kDodgeRangeFast = 45.0f;  // When
 
-  // Check for incoming damage within this range
-  constexpr float kRepelDistance = 10.0f;
+  // Check for incoming damage within this range, if greater than current energy rep
+  constexpr float kRepelDistance = 9.0f;
 
   // How much damage that is going towards an enemy before we start bombing. This is to limit the frequency of our
   // bombing so it overlaps bullets and is harder to dodge.
@@ -161,22 +162,22 @@ std::unique_ptr<behavior::BehaviorNode> DuelBehavior::CreateTree(behavior::Execu
   // How far away a target needs to be before we start varying our shots around the target.
   constexpr float kShotSpreadDistanceThreshold = 40.0f;
 
-  //  If an enemy is near us and we're low energy thor if below this value
-  constexpr float kThorEnemyThreshold = 200.0f;
+  //  If an enemy is near us and we're low energy attempt to pb thor target
+  constexpr float kThorEnemyThreshold = 250.0f;
 
-  // How far away from a teammate before we regroup
-  constexpr float kTeamRange = 40.0f;
+  // Distance away from team before we regroup
+  constexpr float kTeamRange = 40.0f;       // Distance away from team member before we regroup
+  constexpr int kTeamRangeMemberIndex = 3;  // Use the 3rd furthest teammate as the base, otherwise the next furthest
 
-  constexpr float kLeashDistance = 30.0f;
-  constexpr float kLeashDistanceAttack = 20.0f;
+  // Leash Settings
+  constexpr float kLeashDistance = 30.0f;        // Used for low-energy retreating
+  constexpr float kLeashDistanceAttack = 20.0f;  // Used for default attack distance
 
-  constexpr float kAvoidTeamDistance = 8.0f;
-
-  constexpr float kAvoidEnemyDistance = 10.0f;
-
-  constexpr float kMultiFireDistance = 35.0f;  // Use multifire for targets over this range
-
-  constexpr float kAvoidWallDistance = 2.0f;
+  // Misc
+  constexpr float kAvoidTeamDistance = 8.0f;    // Check to ensure we're not all stacked
+  constexpr float kAvoidEnemyDistance = 10.0f;  // Additional check when pathing to prevent enemies from sitting on us
+  constexpr float kMultiFireDistance = 35.0f;   // Use multifire for targets over this range
+  constexpr float kAvoidWallDistance = 3.0f;
 
   // clang-format off
 
@@ -210,20 +211,7 @@ std::unique_ptr<behavior::BehaviorNode> DuelBehavior::CreateTree(behavior::Execu
             .Child<InputActionNode>(InputAction::Bullet)
             .Child<TimerSetNode>("pre_fire", 1500)
             .End()
-      // .Sequence()  //If player shot at us cancel startup/ready check
-           // .InvertChild<TimerExpiredNode>("match_startup")      
-          //  .Child<ScalarThresholdNode<float>>("incoming_damage", "startup_damage_trigger")
-          //  .Child<BlackboardEraseNode>("match_startup")
-          //  .End()
-//       .Sequence() // Switch to own frequency when possible.
-//            .Child<ReadConfigIntNode<u16>>("Freq", "request_freq")
-//            .Child<PlayerFrequencyQueryNode>("self_freq")
-//            .InvertChild<EqualityNode<u16>>("self_freq", "request_freq")
-//            .Child<TimerExpiredNode>("next_freq_change_tick")
-//            .Child<TimerSetNode>("next_freq_change_tick", 300)
-//            .Child<PlayerChangeFrequencyNode>("request_freq")
- //           .End()
-    .Selector() // Choose to fight the player or follow waypoints.
+.Selector() // Choose to fight the player or follow waypoints.
             .Sequence() // Find nearest target and either path to them or seek them directly.              
                 .Sequence(CompositeDecorator::Success)
                     .Child<PlayerPositionQueryNode>("self_position") //Always track self position
@@ -231,13 +219,13 @@ std::unique_ptr<behavior::BehaviorNode> DuelBehavior::CreateTree(behavior::Execu
                     .Child<PlayerPositionQueryNode>("nearest_enemy", "nearest_enemy_position") //Always track nearest enemy position so we can use it for some checks
                     .Child<PlayerEnergyQueryNode>("nearest_enemy", "nearest_enemy_energy")
                     .Child<AimNode>(WeaponType::Bullet, "nearest_enemy", "nearest_aimshot")
-                    .Sequence() 
+                    .Sequence() // Default targert is nearest
                         .Child<NearestMemoryTargetNode>("target")
                         .Child<PlayerPositionQueryNode>("target", "target_position")
                         .Child<PlayerEnergyQueryNode>("target", "target_energy")
                         .Child<AimNode>(WeaponType::Bullet, "target", "aimshot")
                         .End()
-                     .Sequence() //If is someone low nearby override target instead of just using nearest
+                     .Sequence() // If is someone low nearby override target instead of just using nearest
                         .Child<TimerExpiredNode>("recharge_timer") //if we're recharging we should always be leashing to nearest enemy so ignore low health
                         .Child<LowestTargetNode>("lowest_target")
                         .Child<PlayerPositionQueryNode>("lowest_target", "lowest_target_position")
@@ -288,8 +276,7 @@ std::unique_ptr<behavior::BehaviorNode> DuelBehavior::CreateTree(behavior::Execu
                 .Selector()
                     .Sequence() // Attempt to dodge and use defensive items.
                         .Sequence(CompositeDecorator::Success) // Always check incoming damage so we can use it in repel and portal sequences.
-                            .Child<RepelDistanceQueryNode>("repel_distance")
-                            .Child<IncomingDamageQueryNode>("repel_distance", "incoming_damage")
+                            .Child<IncomingDamageQueryNode>(kRepelDistance, "incoming_damage")
                             .Child<PlayerCurrentEnergyQueryNode>("self_energy")
                             .End()
                         .Sequence(CompositeDecorator::Success) // If we are in danger but can't repel, use our portal.
@@ -311,19 +298,20 @@ std::unique_ptr<behavior::BehaviorNode> DuelBehavior::CreateTree(behavior::Execu
                             .InvertChild<ScalarThresholdNode<float>>("target_energy", kLowEnergyRushThreshold)
                             .InvertChild<DistanceThresholdNode>("target_position", "self_position", kRushDistanceThreshold)
                             .End()
-                        .Child<DodgeIncomingDamage>(0.25f, 45.0f) //was .3 30
-                        .End()
-                    .Sequence() //Avoid walls unless we're rushing
-                        .InvertChild<BlackboardSetQueryNode>("rushing")
-                        .InvertChild<TileQueryNode>(kTileIdSafe)
-                        .Child<SeekFromWallNode>(kAvoidWallDistance)
+                        .Sequence(CompositeDecorator::Invert)  // If we're moving fast increase dodge distance threshold
+                                .Child<PlayerVelocityQueryNode>("self_velocity")
+                                .Child<VectorDotNode>("self_velocity", "target_direction", "forward_velocity")
+                                .Child<ScalarThresholdNode<float>>("forward_velocity", kDodgeVelocityThreshold)
+                                .Child<DodgeIncomingDamage>(0.2f, kDodgeRangeFast)
+                                .End()
+                        .Child<DodgeIncomingDamage>(0.1f, kDodgeRangeSlow) //was .3 30
                         .End()
                     .Sequence()  //Keep enemy distance while reacharging, if within seek range face away from target to help dodging
                         .InvertChild<TimerExpiredNode>("recharge_timer")
-                        .Child<SeekNode>("nearest_aimshot", kLeashDistanceAttack, SeekNode::DistanceResolveType::Dynamic)  
-                        .Sequence(CompositeDecorator::Success) // Face away from target so it can dodge while waiting for bomb cooldown.
-                            .InvertChild<DistanceThresholdNode>("nearest_enemy_position", kLeashDistance + 2.0f)  //dont bomb from too far
-                            .Child<DistanceThresholdNode>("nearest_enemy_position", kLeashDistance - 2.0f)  //check to ensure no enemies are on top of us
+                        .Child<SeekNode>("nearest_aimshot", kLeashDistance, SeekNode::DistanceResolveType::Dynamic)  
+                        .Sequence(CompositeDecorator::Success) // Face away from target when at leash range
+                            .InvertChild<DistanceThresholdNode>("nearest_enemy_position", kLeashDistance + 2.0f)  
+                            .Child<DistanceThresholdNode>("nearest_enemy_position", kLeashDistance - 2.0f)  
                             .Child<PerpendicularNode>("nearest_enemy_position", "self_position", "away_dir", true)
                             .Child<VectorSubtractNode>("nearest_enemy_position", "self_position", "target_direction", true)
                             .Child<VectorAddNode>("away_dir", "target_direction", "away_dir", true)
@@ -333,7 +321,7 @@ std::unique_ptr<behavior::BehaviorNode> DuelBehavior::CreateTree(behavior::Execu
                             .End()
                         .End()
                     .Sequence() // Path to teammate if far away
-                        .Child<NearestTeammateNode>("nearest_teammate", 2) //Make sure we have at least 1 teammate close, if more than one stay with the broader group
+                        .Child<NearestTeammateNode>("nearest_teammate", kTeamRangeMemberIndex) //Make sure we have at least 1 teammate close, if more than one stay with the broader group
                         .Child<PlayerPositionQueryNode>("nearest_teammate", "nearest_teammate_position")
                         .Child<DistanceThresholdNode>("nearest_teammate_position", kTeamRange) //If we're already near teammates dont run to them
                         .Child<ScalarThresholdNode<float>>("target_energy", kLowEnergyThreshold)  //If we're going for a kill or someone is diving dont run
@@ -342,6 +330,7 @@ std::unique_ptr<behavior::BehaviorNode> DuelBehavior::CreateTree(behavior::Execu
                         .Child<RenderPathNode>(Vector3f(0.0f, 1.0f, 0.5f))
                         .End()
                     .Sequence() // Path to target if they aren't immediately visible.
+                        .Child<TimerExpiredNode>("match_startup")
                         .InvertChild<VisibilityQueryNode>("target_position")
                         .Child<GoToNode>("target_position")
                         .Parallel(CompositeDecorator::Success)
@@ -358,12 +347,13 @@ std::unique_ptr<behavior::BehaviorNode> DuelBehavior::CreateTree(behavior::Execu
                             .End()
                         .Parallel()     
                             .Child<FaceNode>("aimshot")
-                            .Child<BlackboardEraseNode>("rushing")                      
+                            .Child<BlackboardEraseNode>("rushing")
                             .Selector()
                                .Sequence() // If there is any low target with in this range prioritize
                                     //.Child<ShipItemCountThresholdNode>(ShipItemType::Repel, kRushRepelThreshold) //dont rush if we have no reps
                                     .InvertChild<DistanceThresholdNode>("target_position", "self_position", kLowEnergyDistanceThreshold)
-                                    .InvertChild<ScalarThresholdNode<float>>("target_energy", kLowEnergyRushThreshold)
+                                    .InvertChild<ScalarThresholdNode<float>>("target_energy", kLowEnergyThreshold)
+                                    .Child<ScalarThresholdNode<float>>("self_energy", "target_energy")
                                     .Child<SeekNode>("aimshot", 0.0f, SeekNode::DistanceResolveType::Static)
                                     .Child<ScalarNode>(1.0f, "rushing")
                                     .Child<BlackboardEraseNode>("recharge_timer")
@@ -414,7 +404,6 @@ std::unique_ptr<behavior::BehaviorNode> DuelBehavior::CreateTree(behavior::Execu
                                 .Child<RenderRayNode>("world_camera", "bomb_fire_ray", 50.0f, Vector3f(1.0f, 0.0f, 0.0f))
                                 .Child<RayRectangleInterceptNode>("bomb_fire_ray", "target_bounds")
                                 .Child<InputActionNode>(InputAction::Bomb)
-                               // .InvertChild<TimerSetNode>("recharge_timer", "20")  //add slight backoff after firing a bomb
                                 .End()
                             .Sequence(CompositeDecorator::Success) // PB thor fire check.
                                 .Child<TimerExpiredNode>("match_startup")

--- a/zero/zones/nexus/DuelBehavior.h
+++ b/zero/zones/nexus/DuelBehavior.h
@@ -12,8 +12,6 @@ struct DuelBehavior : public behavior::Behavior {
   void OnInitialize(behavior::ExecuteContext& ctx) override {
     // Setup blackboard here for this specific behavior
     ctx.blackboard.Set("request_ship", 4);
-    ctx.blackboard.Set("leash_distance", 35.0f);
-    ctx.blackboard.Set("run_distance", 50.0f);
     ctx.blackboard.Set("startup_damage_trigger", "50");
 
 

--- a/zero/zones/nexus/FoursBehavior.cpp
+++ b/zero/zones/nexus/FoursBehavior.cpp
@@ -148,7 +148,7 @@ std::unique_ptr<behavior::BehaviorNode> FoursBehavior::CreateTree(behavior::Exec
 
   // Rush threshold / dodge thresholds
   constexpr float kLowEnergyRushThreshold = 300.0f;  // If within rush distance and below this threshold
-  constexpr float kRushDistanceThreshold = 8.0f;    // If below rush energy threshold and this distance
+  constexpr float kRushDistanceThreshold = 10.0f;    // If below rush energy threshold and this distance
   constexpr u32 kRushRepelThreshold = 1;             // If we don't have this many reps dont rush targets
 
   // This is how far away to check for enemies that are rushing at us with low energy.
@@ -156,7 +156,7 @@ std::unique_ptr<behavior::BehaviorNode> FoursBehavior::CreateTree(behavior::Exec
   constexpr float kNearbyEnemyThreshold = 10.0f;
 
   // Check for incoming damage within this range
-  constexpr float kRepelDistance = 10.0f;
+  constexpr float kRepelDistance = 7.0f;
 
   // How much damage that is going towards an enemy before we start bombing. This is to limit the frequency of our
   // bombing so it overlaps bullets and is harder to dodge.

--- a/zero/zones/nexus/FoursBehavior.cpp
+++ b/zero/zones/nexus/FoursBehavior.cpp
@@ -148,7 +148,7 @@ std::unique_ptr<behavior::BehaviorNode> FoursBehavior::CreateTree(behavior::Exec
 
   // Rush threshold / dodge thresholds
   constexpr float kLowEnergyRushThreshold = 300.0f;  // If within rush distance and below this threshold
-  constexpr float kRushDistanceThreshold = 10.0f;    // If below rush energy threshold and this distance
+  constexpr float kRushDistanceThreshold = 8.0f;    // If below rush energy threshold and this distance
   constexpr u32 kRushRepelThreshold = 1;             // If we don't have this many reps dont rush targets
 
   // This is how far away to check for enemies that are rushing at us with low energy.

--- a/zero/zones/nexus/FoursBehavior.cpp
+++ b/zero/zones/nexus/FoursBehavior.cpp
@@ -142,21 +142,22 @@ std::unique_ptr<behavior::BehaviorNode> FoursBehavior::CreateTree(behavior::Exec
 
   const Vector2f center(512, 512);
 
-  // Used for target prio
-  constexpr float kLowEnergyThreshold = 700.0f;         // Energy threshold to prio targets
-  constexpr float kLowEnergyDistanceThreshold = 20.0f;  // Distance threshold for prio targets
+  // Pursue targets below these thresholds, otherwise attack from distance
+  constexpr float kLowEnergyThreshold = 700.0f;         // Energy threshold
+  constexpr float kLowEnergyDistanceThreshold = 18.0f;  // Distance threshold
+  constexpr u32 kRushRepelThreshold = 1;  // If we don't have this many reps dont rush targets (in testing)
 
-  // Rush threshold / dodge thresholds
-  constexpr float kLowEnergyRushThreshold = 300.0f;  // If within rush distance and below this threshold
-  constexpr float kRushDistanceThreshold = 10.0f;    // If below rush energy threshold and this distance
-  constexpr u32 kRushRepelThreshold = 1;             // If we don't have this many reps dont rush targets
+  // Stop attempting to dodge when target is below these thresholds
+  constexpr float kLowEnergyRushThreshold = 300.0f;  // Energy threshold
+  constexpr float kRushDistanceThreshold = 8.0f;     // Distance threshold
 
-  // This is how far away to check for enemies that are rushing at us with low energy.
-  // We will stop dodging and try to finish them off if they are within this distance and low energy.
-  constexpr float kNearbyEnemyThreshold = 10.0f;
+  // Other dodge
+  constexpr float kDodgeVelocityThreshold = 10.0f;
+  constexpr float kDodgeRangeSlow = 20.0f;
+  constexpr float kDodgeRangeFast = 45.0f;  // When
 
-  // Check for incoming damage within this range
-  constexpr float kRepelDistance = 7.0f;
+  // Check for incoming damage within this range, if greater than current energy rep
+  constexpr float kRepelDistance = 9.0f;
 
   // How much damage that is going towards an enemy before we start bombing. This is to limit the frequency of our
   // bombing so it overlaps bullets and is harder to dodge.
@@ -165,38 +166,32 @@ std::unique_ptr<behavior::BehaviorNode> FoursBehavior::CreateTree(behavior::Exec
   // How far away a target needs to be before we start varying our shots around the target.
   constexpr float kShotSpreadDistanceThreshold = 40.0f;
 
-  //  If an enemy is near us and we're low energy thor if below this value
-  constexpr float kThorEnemyThreshold = 200.0f;
+  //  If an enemy is near us and we're low energy attempt to pb thor target
+  constexpr float kThorEnemyThreshold = 250.0f;
 
-  // How far away from a teammate before we regroup
-  constexpr float kTeamRange = 40.0f;
+  // Distance away from team before we regroup
+  constexpr float kTeamRange = 45.0f;       // Distance away from team member before we regroup
+  constexpr int kTeamRangeMemberIndex = 3;  // Use the 3rd furthest teammate as the base, otherwise the next furthest
 
-  constexpr float kLeashDistance = 30.0f;
-  constexpr float kLeashDistanceAttack = 20.0f;
+  // Leash Settings
+  constexpr float kLeashDistance = 30.0f;        // Used for low-energy retreating
+  constexpr float kLeashDistanceAttack = 20.0f;  // Used for default attack distance
 
-  constexpr float kAvoidTeamDistance = 8.0f;
-
-  constexpr float kAvoidEnemyDistance = 10.0f;
-
-  constexpr float kMultiFireDistance = 35.0f;  // Use multifire for targets over this range
-
+  // Misc
+  constexpr float kAvoidTeamDistance = 8.0f;    // Check to ensure we're not all stacked
+  constexpr float kAvoidEnemyDistance = 10.0f;  // Additional check when pathing to prevent enemies from sitting on us
+  constexpr float kMultiFireDistance = 35.0f;   // Use multifire for targets over this range
   constexpr float kAvoidWallDistance = 3.0f;
 
-  //.Child<ReadConfigIntNode<u16>>("queue_command1", "command1")
-  //.Child<ReadConfigIntNode<u16>>("queue_command2", "command2")
-  //.Child<ReadConfigIntNode<u16>>("queue_command3", "command3")
-  //.Child<ChatMessageNode>(ChatMessageNode::PublicBlackboard("command1")) // Invert so this fails and freq is
-  //reevaluated. .Child<ChatMessageNode>(ChatMessageNode::PublicBlackboard("command2")) // Invert so this fails and freq
-  //is reevaluated. .Child<ChatMessageNode>(ChatMessageNode::PublicBlackboard("command3")) // Invert so this fails and
-  //freq is reevaluated.
   // clang-format off
   builder
     .Selector()
+         .InvertChild<PlayerSelfNode>("self")
         .Sequence() //Join the queue first thing and auto join TODO: add command or checks to requeue if something goes wrong later such as recycled arena
             //.InvertChild<BlackboardSetQueryNode>("queued") //Check if we have already joined the queue, if not join
             .Child<TimerExpiredNode>("queue")
             .Child<ChatMessageNode>(ChatMessageNode::Public("?next 4v4pub")) // Invert so this fails and freq is reevaluated.  //TODO replace this with a config var so we dont need 4 behaviors
-            .Child<ChatMessageNode>(ChatMessageNode::Public("?next -a")) // Invert so this fails and freq is reevaluated.
+            .Child<ChatMessageNode>(ChatMessageNode::Public("?return")) // Invert so this fails and freq is reevaluated.  //TODO replace this with a config var so we dont need 4 behaviors
             .Child<TimerSetNode>("queue", 6000)
             //.Child<ScalarNode>(1.0f, "queued")  //was only joining queue on join then stopped working
             .End()
@@ -222,20 +217,26 @@ std::unique_ptr<behavior::BehaviorNode> FoursBehavior::CreateTree(behavior::Exec
             .Child<InputActionNode>(InputAction::Bullet)
             .Child<TimerSetNode>("pre_fire", 1500)
             .End()
-      // .Sequence()  //If player shot at us cancel startup/ready check
-           // .InvertChild<TimerExpiredNode>("match_startup")      
-          //  .Child<ScalarThresholdNode<float>>("incoming_damage", "startup_damage_trigger")
-          //  .Child<BlackboardEraseNode>("match_startup")
-          //  .End()
-//       .Sequence() // Switch to own frequency when possible.
-//            .Child<ReadConfigIntNode<u16>>("Freq", "request_freq")
-//            .Child<PlayerFrequencyQueryNode>("self_freq")
-//            .InvertChild<EqualityNode<u16>>("self_freq", "request_freq")
-//            .Child<TimerExpiredNode>("next_freq_change_tick")
-//            .Child<TimerSetNode>("next_freq_change_tick", 300)
-//            .Child<PlayerChangeFrequencyNode>("request_freq")
- //           .End()
-   .Selector() // Choose to fight the player or follow waypoints.
+        .Sequence() //Attach if someone is safe and we have full energy
+            .Child<BlackboardSetQueryNode>("tchat_safe")
+            .InvertChild<TimerExpiredNode>("tchat_safe_timer")
+            .Child<PlayerEnergyPercentThresholdNode>(1.0f)
+            .Child<TimerExpiredNode>("attach_cooldown")
+            .InvertChild<AttachedQueryNode>("self")
+            .Child<NearestTeammateNode>("nearest_teammate") 
+            .Child<PlayerPositionQueryNode>("nearest_teammate", "nearest_teammate_position")
+            .Child<DistanceThresholdNode>("nearest_teammate_position", kTeamRange) //If we're already near teammates dont run to them               
+            .Child<PlayerByNameNode>("tchat_safe", "tchat_safe_player")
+            .Child<AttachNode>("tchat_safe_player")
+            .Child<TimerSetNode>("attach_cooldown", 100)
+            .Child<BlackboardEraseNode>("tchat_safe")
+            .Child<BlackboardEraseNode>("tchat_safe_timer")
+            .End()
+        .Sequence() // Detach if attached
+            .Child<AttachedQueryNode>("self")
+            .Child<DetachNode>()
+            .End()
+.Selector() // Choose to fight the player or follow waypoints.
             .Sequence() // Find nearest target and either path to them or seek them directly.              
                 .Sequence(CompositeDecorator::Success)
                     .Child<PlayerPositionQueryNode>("self_position") //Always track self position
@@ -243,13 +244,13 @@ std::unique_ptr<behavior::BehaviorNode> FoursBehavior::CreateTree(behavior::Exec
                     .Child<PlayerPositionQueryNode>("nearest_enemy", "nearest_enemy_position") //Always track nearest enemy position so we can use it for some checks
                     .Child<PlayerEnergyQueryNode>("nearest_enemy", "nearest_enemy_energy")
                     .Child<AimNode>(WeaponType::Bullet, "nearest_enemy", "nearest_aimshot")
-                    .Sequence() 
+                    .Sequence() // Default targert is nearest
                         .Child<NearestMemoryTargetNode>("target")
                         .Child<PlayerPositionQueryNode>("target", "target_position")
                         .Child<PlayerEnergyQueryNode>("target", "target_energy")
                         .Child<AimNode>(WeaponType::Bullet, "target", "aimshot")
                         .End()
-                     .Sequence() //If is someone low nearby override target instead of just using nearest
+                     .Sequence() // If is someone low nearby override target instead of just using nearest
                         .Child<TimerExpiredNode>("recharge_timer") //if we're recharging we should always be leashing to nearest enemy so ignore low health
                         .Child<LowestTargetNode>("lowest_target")
                         .Child<PlayerPositionQueryNode>("lowest_target", "lowest_target_position")
@@ -300,8 +301,7 @@ std::unique_ptr<behavior::BehaviorNode> FoursBehavior::CreateTree(behavior::Exec
                 .Selector()
                     .Sequence() // Attempt to dodge and use defensive items.
                         .Sequence(CompositeDecorator::Success) // Always check incoming damage so we can use it in repel and portal sequences.
-                            .Child<RepelDistanceQueryNode>("repel_distance")
-                            .Child<IncomingDamageQueryNode>("repel_distance", "incoming_damage")
+                            .Child<IncomingDamageQueryNode>(kRepelDistance, "incoming_damage")
                             .Child<PlayerCurrentEnergyQueryNode>("self_energy")
                             .End()
                         .Sequence(CompositeDecorator::Success) // If we are in danger but can't repel, use our portal.
@@ -323,14 +323,20 @@ std::unique_ptr<behavior::BehaviorNode> FoursBehavior::CreateTree(behavior::Exec
                             .InvertChild<ScalarThresholdNode<float>>("target_energy", kLowEnergyRushThreshold)
                             .InvertChild<DistanceThresholdNode>("target_position", "self_position", kRushDistanceThreshold)
                             .End()
-                        .Child<DodgeIncomingDamage>(0.25f, 45.0f) //was .3 30
+                        .Sequence(CompositeDecorator::Invert)  // If we're moving fast increase dodge distance threshold
+                                .Child<PlayerVelocityQueryNode>("self_velocity")
+                                .Child<VectorDotNode>("self_velocity", "target_direction", "forward_velocity")
+                                .Child<ScalarThresholdNode<float>>("forward_velocity", kDodgeVelocityThreshold)
+                                .Child<DodgeIncomingDamage>(0.2f, kDodgeRangeFast)
+                                .End()
+                        .Child<DodgeIncomingDamage>(0.1f, kDodgeRangeSlow) //was .3 30
                         .End()
                     .Sequence()  //Keep enemy distance while reacharging, if within seek range face away from target to help dodging
                         .InvertChild<TimerExpiredNode>("recharge_timer")
-                        .Child<SeekNode>("nearest_aimshot", kLeashDistanceAttack, SeekNode::DistanceResolveType::Dynamic)  
-                        .Sequence(CompositeDecorator::Success) // Face away from target so it can dodge while waiting for bomb cooldown.
-                            .InvertChild<DistanceThresholdNode>("nearest_enemy_position", kLeashDistance + 2.0f)  //dont bomb from too far
-                            .Child<DistanceThresholdNode>("nearest_enemy_position", kLeashDistance - 2.0f)  //check to ensure no enemies are on top of us
+                        .Child<SeekNode>("nearest_aimshot", kLeashDistance, SeekNode::DistanceResolveType::Dynamic)  
+                        .Sequence(CompositeDecorator::Success) // Face away from target when at leash range
+                            .InvertChild<DistanceThresholdNode>("nearest_enemy_position", kLeashDistance + 2.0f)  
+                            .Child<DistanceThresholdNode>("nearest_enemy_position", kLeashDistance - 2.0f)  
                             .Child<PerpendicularNode>("nearest_enemy_position", "self_position", "away_dir", true)
                             .Child<VectorSubtractNode>("nearest_enemy_position", "self_position", "target_direction", true)
                             .Child<VectorAddNode>("away_dir", "target_direction", "away_dir", true)
@@ -340,7 +346,7 @@ std::unique_ptr<behavior::BehaviorNode> FoursBehavior::CreateTree(behavior::Exec
                             .End()
                         .End()
                     .Sequence() // Path to teammate if far away
-                        .Child<NearestTeammateNode>("nearest_teammate", 2) //Make sure we have at least 1 teammate close, if more than one stay with the broader group
+                        .Child<NearestTeammateNode>("nearest_teammate", kTeamRangeMemberIndex) //Make sure we have at least 1 teammate close, if more than one stay with the broader group
                         .Child<PlayerPositionQueryNode>("nearest_teammate", "nearest_teammate_position")
                         .Child<DistanceThresholdNode>("nearest_teammate_position", kTeamRange) //If we're already near teammates dont run to them
                         .Child<ScalarThresholdNode<float>>("target_energy", kLowEnergyThreshold)  //If we're going for a kill or someone is diving dont run
@@ -349,6 +355,7 @@ std::unique_ptr<behavior::BehaviorNode> FoursBehavior::CreateTree(behavior::Exec
                         .Child<RenderPathNode>(Vector3f(0.0f, 1.0f, 0.5f))
                         .End()
                     .Sequence() // Path to target if they aren't immediately visible.
+                        .Child<TimerExpiredNode>("match_startup")
                         .InvertChild<VisibilityQueryNode>("target_position")
                         .Child<GoToNode>("target_position")
                         .Parallel(CompositeDecorator::Success)
@@ -365,7 +372,7 @@ std::unique_ptr<behavior::BehaviorNode> FoursBehavior::CreateTree(behavior::Exec
                             .End()
                         .Parallel()     
                             .Child<FaceNode>("aimshot")
-                            .Child<BlackboardEraseNode>("rushing")                      
+                            .Child<BlackboardEraseNode>("rushing")
                             .Selector()
                                .Sequence() // If there is any low target with in this range prioritize
                                     //.Child<ShipItemCountThresholdNode>(ShipItemType::Repel, kRushRepelThreshold) //dont rush if we have no reps
@@ -422,7 +429,6 @@ std::unique_ptr<behavior::BehaviorNode> FoursBehavior::CreateTree(behavior::Exec
                                 .Child<RenderRayNode>("world_camera", "bomb_fire_ray", 50.0f, Vector3f(1.0f, 0.0f, 0.0f))
                                 .Child<RayRectangleInterceptNode>("bomb_fire_ray", "target_bounds")
                                 .Child<InputActionNode>(InputAction::Bomb)
-                               // .InvertChild<TimerSetNode>("recharge_timer", "20")  //add slight backoff after firing a bomb
                                 .End()
                             .Sequence(CompositeDecorator::Success) // PB thor fire check.
                                 .Child<TimerExpiredNode>("match_startup")

--- a/zero/zones/nexus/FoursBehavior.h
+++ b/zero/zones/nexus/FoursBehavior.h
@@ -12,8 +12,6 @@ struct FoursBehavior : public behavior::Behavior {
   void OnInitialize(behavior::ExecuteContext& ctx) override {
     // Setup blackboard here for this specific behavior
     ctx.blackboard.Set("request_ship", 4);
-    ctx.blackboard.Set("leash_distance", 30.0f);
-    ctx.blackboard.Set("run_distance", 50.0f);
     ctx.blackboard.Set("startup_damage_trigger", "50");
 
 

--- a/zero/zones/nexus/TestBehavior.cpp
+++ b/zero/zones/nexus/TestBehavior.cpp
@@ -112,21 +112,22 @@ std::unique_ptr<behavior::BehaviorNode> TestBehavior::CreateTree(behavior::Execu
 
   const Vector2f center(512, 512);
 
-  // Used for target prio
-  constexpr float kLowEnergyThreshold = 700.0f;         // Energy threshold to prio targets
-  constexpr float kLowEnergyDistanceThreshold = 20.0f;  // Distance threshold for prio targets
+  // Pursue targets below these thresholds, otherwise attack from distance
+  constexpr float kLowEnergyThreshold = 700.0f;         // Energy threshold
+  constexpr float kLowEnergyDistanceThreshold = 18.0f;  // Distance threshold
+  constexpr u32 kRushRepelThreshold = 1;  // If we don't have this many reps dont rush targets (in testing)
 
-  // Rush threshold / dodge thresholds
-  constexpr float kLowEnergyRushThreshold = 300.0f;  // If within rush distance and below this threshold
-  constexpr float kRushDistanceThreshold = 10.0f;    // If below rush energy threshold and this distance
-  constexpr u32 kRushRepelThreshold = 1;             // If we don't have this many reps dont rush targets
+  // Stop attempting to dodge when target is below these thresholds
+  constexpr float kLowEnergyRushThreshold = 300.0f;  // Energy threshold
+  constexpr float kRushDistanceThreshold = 8.0f;     // Distance threshold
 
-  // This is how far away to check for enemies that are rushing at us with low energy.
-  // We will stop dodging and try to finish them off if they are within this distance and low energy.
-  constexpr float kNearbyEnemyThreshold = 10.0f;
+  // Other dodge
+  constexpr float kDodgeVelocityThreshold = 10.0f;
+  constexpr float kDodgeRangeSlow = 20.0f;
+  constexpr float kDodgeRangeFast = 45.0f;  // When
 
-  // Check for incoming damage within this range
-  constexpr float kRepelDistance = 7.0f;
+  // Check for incoming damage within this range, if greater than current energy rep
+  constexpr float kRepelDistance = 9.0f;
 
   // How much damage that is going towards an enemy before we start bombing. This is to limit the frequency of our
   // bombing so it overlaps bullets and is harder to dodge.
@@ -135,24 +136,24 @@ std::unique_ptr<behavior::BehaviorNode> TestBehavior::CreateTree(behavior::Execu
   // How far away a target needs to be before we start varying our shots around the target.
   constexpr float kShotSpreadDistanceThreshold = 40.0f;
 
-  //  If an enemy is near us and we're low energy thor if below this value
-  constexpr float kThorEnemyThreshold = 200.0f;
+  //  If an enemy is near us and we're low energy attempt to pb thor target
+  constexpr float kThorEnemyThreshold = 250.0f;
 
-  // How far away from a teammate before we regroup
-  constexpr float kTeamRange = 40.0f;
+  // Distance away from team before we regroup
+  constexpr float kTeamRange = 45.0f;       // Distance away from team member before we regroup
+  constexpr int kTeamRangeMemberIndex = 3;  // Use the 3rd furthest teammate as the base, otherwise the next furthest
 
-  constexpr float kLeashDistance = 30.0f;
-  constexpr float kLeashDistanceAttack = 20.0f;
+  // Leash Settings
+  constexpr float kLeashDistance = 30.0f;        // Used for low-energy retreating
+  constexpr float kLeashDistanceAttack = 20.0f;  // Used for default attack distance
 
-  constexpr float kAvoidTeamDistance = 8.0f;
-
-  constexpr float kAvoidEnemyDistance = 10.0f;
-
-  constexpr float kMultiFireDistance = 35.0f;  // Use multifire for targets over this range
-
+  // Misc
+  constexpr float kAvoidTeamDistance = 8.0f;    // Check to ensure we're not all stacked
+  constexpr float kAvoidEnemyDistance = 10.0f;  // Additional check when pathing to prevent enemies from sitting on us
+  constexpr float kMultiFireDistance = 35.0f;   // Use multifire for targets over this range
   constexpr float kAvoidWallDistance = 3.0f;
-
   // clang-format off
+
   builder
     .Selector()
         .InvertChild<PlayerSelfNode>("self")
@@ -179,15 +180,7 @@ std::unique_ptr<behavior::BehaviorNode> TestBehavior::CreateTree(behavior::Execu
             .Child<AttachedQueryNode>("self")
             .Child<DetachNode>()
             .End()
-     //  .Sequence() // Switch to own frequency when possible.
-     //       .Child<ReadConfigIntNode<u16>>("Freq", "request_freq")
-     //       .Child<PlayerFrequencyQueryNode>("self_freq")
-     //       .InvertChild<EqualityNode<u16>>("self_freq", "request_freq")
-     //       .Child<TimerExpiredNode>("next_freq_change_tick")
-     //       .Child<TimerSetNode>("next_freq_change_tick", 300)
-     //       .Child<PlayerChangeFrequencyNode>("request_freq")
-     //       .End()
-   .Selector() // Choose to fight the player or follow waypoints.
+.Selector() // Choose to fight the player or follow waypoints.
             .Sequence() // Find nearest target and either path to them or seek them directly.              
                 .Sequence(CompositeDecorator::Success)
                     .Child<PlayerPositionQueryNode>("self_position") //Always track self position
@@ -195,13 +188,13 @@ std::unique_ptr<behavior::BehaviorNode> TestBehavior::CreateTree(behavior::Execu
                     .Child<PlayerPositionQueryNode>("nearest_enemy", "nearest_enemy_position") //Always track nearest enemy position so we can use it for some checks
                     .Child<PlayerEnergyQueryNode>("nearest_enemy", "nearest_enemy_energy")
                     .Child<AimNode>(WeaponType::Bullet, "nearest_enemy", "nearest_aimshot")
-                    .Sequence() 
+                    .Sequence() // Default targert is nearest
                         .Child<NearestMemoryTargetNode>("target")
                         .Child<PlayerPositionQueryNode>("target", "target_position")
                         .Child<PlayerEnergyQueryNode>("target", "target_energy")
                         .Child<AimNode>(WeaponType::Bullet, "target", "aimshot")
                         .End()
-                     .Sequence() //If is someone low nearby override target instead of just using nearest
+                     .Sequence() // If is someone low nearby override target instead of just using nearest
                         .Child<TimerExpiredNode>("recharge_timer") //if we're recharging we should always be leashing to nearest enemy so ignore low health
                         .Child<LowestTargetNode>("lowest_target")
                         .Child<PlayerPositionQueryNode>("lowest_target", "lowest_target_position")
@@ -252,8 +245,7 @@ std::unique_ptr<behavior::BehaviorNode> TestBehavior::CreateTree(behavior::Execu
                 .Selector()
                     .Sequence() // Attempt to dodge and use defensive items.
                         .Sequence(CompositeDecorator::Success) // Always check incoming damage so we can use it in repel and portal sequences.
-                            .Child<RepelDistanceQueryNode>("repel_distance")
-                            .Child<IncomingDamageQueryNode>("repel_distance", "incoming_damage")
+                            .Child<IncomingDamageQueryNode>(kRepelDistance, "incoming_damage")
                             .Child<PlayerCurrentEnergyQueryNode>("self_energy")
                             .End()
                         .Sequence(CompositeDecorator::Success) // If we are in danger but can't repel, use our portal.
@@ -275,14 +267,20 @@ std::unique_ptr<behavior::BehaviorNode> TestBehavior::CreateTree(behavior::Execu
                             .InvertChild<ScalarThresholdNode<float>>("target_energy", kLowEnergyRushThreshold)
                             .InvertChild<DistanceThresholdNode>("target_position", "self_position", kRushDistanceThreshold)
                             .End()
-                        .Child<DodgeIncomingDamage>(0.25f, 45.0f) //was .3 30
+                        .Sequence(CompositeDecorator::Invert)  // If we're moving fast increase dodge distance threshold
+                                .Child<PlayerVelocityQueryNode>("self_velocity")
+                                .Child<VectorDotNode>("self_velocity", "target_direction", "forward_velocity")
+                                .Child<ScalarThresholdNode<float>>("forward_velocity", kDodgeVelocityThreshold)
+                                .Child<DodgeIncomingDamage>(0.2f, kDodgeRangeFast)
+                                .End()
+                        .Child<DodgeIncomingDamage>(0.1f, kDodgeRangeSlow) //was .3 30
                         .End()
                     .Sequence()  //Keep enemy distance while reacharging, if within seek range face away from target to help dodging
                         .InvertChild<TimerExpiredNode>("recharge_timer")
-                        .Child<SeekNode>("nearest_aimshot", kLeashDistanceAttack, SeekNode::DistanceResolveType::Dynamic)  
-                        .Sequence(CompositeDecorator::Success) // Face away from target so it can dodge while waiting for bomb cooldown.
-                            .InvertChild<DistanceThresholdNode>("nearest_enemy_position", kLeashDistance + 2.0f)  //dont bomb from too far
-                            .Child<DistanceThresholdNode>("nearest_enemy_position", kLeashDistance - 2.0f)  //check to ensure no enemies are on top of us
+                        .Child<SeekNode>("nearest_aimshot", kLeashDistance, SeekNode::DistanceResolveType::Dynamic)  
+                        .Sequence(CompositeDecorator::Success) // Face away from target when at leash range
+                            .InvertChild<DistanceThresholdNode>("nearest_enemy_position", kLeashDistance + 2.0f)  
+                            .Child<DistanceThresholdNode>("nearest_enemy_position", kLeashDistance - 2.0f)  
                             .Child<PerpendicularNode>("nearest_enemy_position", "self_position", "away_dir", true)
                             .Child<VectorSubtractNode>("nearest_enemy_position", "self_position", "target_direction", true)
                             .Child<VectorAddNode>("away_dir", "target_direction", "away_dir", true)
@@ -292,7 +290,7 @@ std::unique_ptr<behavior::BehaviorNode> TestBehavior::CreateTree(behavior::Execu
                             .End()
                         .End()
                     .Sequence() // Path to teammate if far away
-                        .Child<NearestTeammateNode>("nearest_teammate", 2) //Make sure we have at least 1 teammate close, if more than one stay with the broader group
+                        .Child<NearestTeammateNode>("nearest_teammate", kTeamRangeMemberIndex) //Make sure we have at least 1 teammate close, if more than one stay with the broader group
                         .Child<PlayerPositionQueryNode>("nearest_teammate", "nearest_teammate_position")
                         .Child<DistanceThresholdNode>("nearest_teammate_position", kTeamRange) //If we're already near teammates dont run to them
                         .Child<ScalarThresholdNode<float>>("target_energy", kLowEnergyThreshold)  //If we're going for a kill or someone is diving dont run
@@ -301,6 +299,7 @@ std::unique_ptr<behavior::BehaviorNode> TestBehavior::CreateTree(behavior::Execu
                         .Child<RenderPathNode>(Vector3f(0.0f, 1.0f, 0.5f))
                         .End()
                     .Sequence() // Path to target if they aren't immediately visible.
+                        .Child<TimerExpiredNode>("match_startup")
                         .InvertChild<VisibilityQueryNode>("target_position")
                         .Child<GoToNode>("target_position")
                         .Parallel(CompositeDecorator::Success)
@@ -317,7 +316,7 @@ std::unique_ptr<behavior::BehaviorNode> TestBehavior::CreateTree(behavior::Execu
                             .End()
                         .Parallel()     
                             .Child<FaceNode>("aimshot")
-                            .Child<BlackboardEraseNode>("rushing")                      
+                            .Child<BlackboardEraseNode>("rushing")
                             .Selector()
                                .Sequence() // If there is any low target with in this range prioritize
                                     //.Child<ShipItemCountThresholdNode>(ShipItemType::Repel, kRushRepelThreshold) //dont rush if we have no reps
@@ -374,7 +373,6 @@ std::unique_ptr<behavior::BehaviorNode> TestBehavior::CreateTree(behavior::Execu
                                 .Child<RenderRayNode>("world_camera", "bomb_fire_ray", 50.0f, Vector3f(1.0f, 0.0f, 0.0f))
                                 .Child<RayRectangleInterceptNode>("bomb_fire_ray", "target_bounds")
                                 .Child<InputActionNode>(InputAction::Bomb)
-                               // .InvertChild<TimerSetNode>("recharge_timer", "20")  //add slight backoff after firing a bomb
                                 .End()
                             .Sequence(CompositeDecorator::Success) // PB thor fire check.
                                 .Child<TimerExpiredNode>("match_startup")

--- a/zero/zones/nexus/TestBehavior.cpp
+++ b/zero/zones/nexus/TestBehavior.cpp
@@ -126,7 +126,7 @@ std::unique_ptr<behavior::BehaviorNode> TestBehavior::CreateTree(behavior::Execu
   constexpr float kNearbyEnemyThreshold = 10.0f;
 
   // Check for incoming damage within this range
-  constexpr float kRepelDistance = 8.0f;
+  constexpr float kRepelDistance = 7.0f;
 
   // How much damage that is going towards an enemy before we start bombing. This is to limit the frequency of our
   // bombing so it overlaps bullets and is harder to dodge.

--- a/zero/zones/nexus/TestBehavior.cpp
+++ b/zero/zones/nexus/TestBehavior.cpp
@@ -126,7 +126,7 @@ std::unique_ptr<behavior::BehaviorNode> TestBehavior::CreateTree(behavior::Execu
   constexpr float kNearbyEnemyThreshold = 10.0f;
 
   // Check for incoming damage within this range
-  constexpr float kRepelDistance = 10.0f;
+  constexpr float kRepelDistance = 8.0f;
 
   // How much damage that is going towards an enemy before we start bombing. This is to limit the frequency of our
   // bombing so it overlaps bullets and is harder to dodge.

--- a/zero/zones/nexus/TestBehavior.h
+++ b/zero/zones/nexus/TestBehavior.h
@@ -12,8 +12,6 @@ struct TestBehavior : public behavior::Behavior {
   void OnInitialize(behavior::ExecuteContext& ctx) override {
     // Setup blackboard here for this specific behavior
     ctx.blackboard.Set("request_ship", 4);
-    ctx.blackboard.Set("leash_distance", 45.0f);
-    ctx.blackboard.Set("run_distance", 200.0f);
 
     std::vector<Vector2f> waypoints{
         Vector2f(410, 415), Vector2f(615, 395), Vector2f(515, 545), Vector2f(505, 680), Vector2f(355, 545),

--- a/zero/zones/nexus/ThreesBehavior.cpp
+++ b/zero/zones/nexus/ThreesBehavior.cpp
@@ -156,7 +156,7 @@ std::unique_ptr<behavior::BehaviorNode> ThreesBehavior::CreateTree(behavior::Exe
   constexpr float kNearbyEnemyThreshold = 10.0f;
 
   // Check for incoming damage within this range
-  constexpr float kRepelDistance = 8.0f;
+  constexpr float kRepelDistance = 7.0f;
 
   // How much damage that is going towards an enemy before we start bombing. This is to limit the frequency of our
   // bombing so it overlaps bullets and is harder to dodge.

--- a/zero/zones/nexus/ThreesBehavior.cpp
+++ b/zero/zones/nexus/ThreesBehavior.cpp
@@ -156,7 +156,7 @@ std::unique_ptr<behavior::BehaviorNode> ThreesBehavior::CreateTree(behavior::Exe
   constexpr float kNearbyEnemyThreshold = 10.0f;
 
   // Check for incoming damage within this range
-  constexpr float kRepelDistance = 10.0f;
+  constexpr float kRepelDistance = 8.0f;
 
   // How much damage that is going towards an enemy before we start bombing. This is to limit the frequency of our
   // bombing so it overlaps bullets and is harder to dodge.

--- a/zero/zones/nexus/ThreesBehavior.cpp
+++ b/zero/zones/nexus/ThreesBehavior.cpp
@@ -142,21 +142,22 @@ std::unique_ptr<behavior::BehaviorNode> ThreesBehavior::CreateTree(behavior::Exe
 
   const Vector2f center(512, 512);
 
- // Used for target prio
-  constexpr float kLowEnergyThreshold = 700.0f;         // Energy threshold to prio targets
-  constexpr float kLowEnergyDistanceThreshold = 15.0f;  // Distance threshold for prio targets
+  // Pursue targets below these thresholds, otherwise attack from distance
+  constexpr float kLowEnergyThreshold = 700.0f;         // Energy threshold
+  constexpr float kLowEnergyDistanceThreshold = 18.0f;  // Distance threshold
+  constexpr u32 kRushRepelThreshold = 1;  // If we don't have this many reps dont rush targets (in testing)
 
-  // Stop dodging thresholds
-  constexpr float kLowEnergyRushThreshold = 300.0f;  // If within rush distance and below this threshold
-  constexpr float kRushDistanceThreshold = 8.0f;    // If below rush energy threshold and this distance
-  constexpr u32 kRushRepelThreshold = 1;             // If we don't have this many reps dont rush targets
+  // Stop attempting to dodge when target is below these thresholds
+  constexpr float kLowEnergyRushThreshold = 300.0f;  // Energy threshold
+  constexpr float kRushDistanceThreshold = 8.0f;     // Distance threshold
 
-  // This is how far away to check for enemies that are rushing at us with low energy.
-  // We will stop dodging and try to finish them off if they are within this distance and low energy.
-  constexpr float kNearbyEnemyThreshold = 10.0f;
+  // Other dodge
+  constexpr float kDodgeVelocityThreshold = 10.0f;
+  constexpr float kDodgeRangeSlow = 20.0f;
+  constexpr float kDodgeRangeFast = 45.0f;  // When
 
-  // Check for incoming damage within this range
-  constexpr float kRepelDistance = 7.0f;
+  // Check for incoming damage within this range, if greater than current energy rep
+  constexpr float kRepelDistance = 9.0f;
 
   // How much damage that is going towards an enemy before we start bombing. This is to limit the frequency of our
   // bombing so it overlaps bullets and is harder to dodge.
@@ -165,39 +166,32 @@ std::unique_ptr<behavior::BehaviorNode> ThreesBehavior::CreateTree(behavior::Exe
   // How far away a target needs to be before we start varying our shots around the target.
   constexpr float kShotSpreadDistanceThreshold = 40.0f;
 
-  //  If an enemy is near us and we're low energy thor if below this value
-  constexpr float kThorEnemyThreshold = 200.0f;
+  //  If an enemy is near us and we're low energy attempt to pb thor target
+  constexpr float kThorEnemyThreshold = 250.0f;
 
-  // How far away from a teammate before we regroup
-  constexpr float kTeamRange = 40.0f;
+  // Distance away from team before we regroup
+  constexpr float kTeamRange = 45.0f;       // Distance away from team member before we regroup
+  constexpr int kTeamRangeMemberIndex = 3;  // Use the 3rd furthest teammate as the base, otherwise the next furthest
 
-  constexpr float kLeashDistance = 30.0f;
-  constexpr float kLeashDistanceAttack = 20.0f;
+  // Leash Settings
+  constexpr float kLeashDistance = 30.0f;        // Used for low-energy retreating
+  constexpr float kLeashDistanceAttack = 20.0f;  // Used for default attack distance
 
-  constexpr float kAvoidTeamDistance = 8.0f;
-
-  constexpr float kAvoidEnemyDistance = 10.0f;
-
-  constexpr float kMultiFireDistance = 35.0f;  // Use multifire for targets over this range
-
+  // Misc
+  constexpr float kAvoidTeamDistance = 8.0f;    // Check to ensure we're not all stacked
+  constexpr float kAvoidEnemyDistance = 10.0f;  // Additional check when pathing to prevent enemies from sitting on us
+  constexpr float kMultiFireDistance = 35.0f;   // Use multifire for targets over this range
   constexpr float kAvoidWallDistance = 3.0f;
 
-  //.Child<ReadConfigIntNode<u16>>("queue_command1", "command1")
-  //.Child<ReadConfigIntNode<u16>>("queue_command2", "command2")
-  //.Child<ReadConfigIntNode<u16>>("queue_command3", "command3")
-  //.Child<ChatMessageNode>(ChatMessageNode::PublicBlackboard("command1")) // Invert so this fails and freq is
-  //reevaluated. .Child<ChatMessageNode>(ChatMessageNode::PublicBlackboard("command2")) // Invert so this fails and freq
-  //is reevaluated. .Child<ChatMessageNode>(ChatMessageNode::PublicBlackboard("command3")) // Invert so this fails and
-  //freq is reevaluated.
   // clang-format off
   builder
     .Selector()
-        .InvertChild<PlayerSelfNode>("self")
+         .InvertChild<PlayerSelfNode>("self")
         .Sequence() //Join the queue first thing and auto join TODO: add command or checks to requeue if something goes wrong later such as recycled arena
             //.InvertChild<BlackboardSetQueryNode>("queued") //Check if we have already joined the queue, if not join
             .Child<TimerExpiredNode>("queue")
             .Child<ChatMessageNode>(ChatMessageNode::Public("?next 3v3pub")) // Invert so this fails and freq is reevaluated.  //TODO replace this with a config var so we dont need 4 behaviors
-            .Child<ChatMessageNode>(ChatMessageNode::Public("?next -a")) // Invert so this fails and freq is reevaluated.
+            .Child<ChatMessageNode>(ChatMessageNode::Public("?return")) // Invert so this fails and freq is reevaluated.  //TODO replace this with a config var so we dont need 4 behaviors
             .Child<TimerSetNode>("queue", 6000)
             //.Child<ScalarNode>(1.0f, "queued")  //was only joining queue on join then stopped working
             .End()
@@ -231,7 +225,7 @@ std::unique_ptr<behavior::BehaviorNode> ThreesBehavior::CreateTree(behavior::Exe
             .InvertChild<AttachedQueryNode>("self")
             .Child<NearestTeammateNode>("nearest_teammate") 
             .Child<PlayerPositionQueryNode>("nearest_teammate", "nearest_teammate_position")
-            .Child<DistanceThresholdNode>("nearest_teammate_position", kTeamRange) //If we're already near teammates dont attach to them               
+            .Child<DistanceThresholdNode>("nearest_teammate_position", kTeamRange) //If we're already near teammates dont run to them               
             .Child<PlayerByNameNode>("tchat_safe", "tchat_safe_player")
             .Child<AttachNode>("tchat_safe_player")
             .Child<TimerSetNode>("attach_cooldown", 100)
@@ -242,20 +236,7 @@ std::unique_ptr<behavior::BehaviorNode> ThreesBehavior::CreateTree(behavior::Exe
             .Child<AttachedQueryNode>("self")
             .Child<DetachNode>()
             .End()
-      // .Sequence()  //If player shot at us cancel startup/ready check
-           // .InvertChild<TimerExpiredNode>("match_startup")      
-          //  .Child<ScalarThresholdNode<float>>("incoming_damage", "startup_damage_trigger")
-          //  .Child<BlackboardEraseNode>("match_startup")
-          //  .End()
-//       .Sequence() // Switch to own frequency when possible.
-//            .Child<ReadConfigIntNode<u16>>("Freq", "request_freq")
-//            .Child<PlayerFrequencyQueryNode>("self_freq")
-//            .InvertChild<EqualityNode<u16>>("self_freq", "request_freq")
-//            .Child<TimerExpiredNode>("next_freq_change_tick")
-//            .Child<TimerSetNode>("next_freq_change_tick", 300)
-//            .Child<PlayerChangeFrequencyNode>("request_freq")
- //           .End()
-   .Selector() // Choose to fight the player or follow waypoints.
+.Selector() // Choose to fight the player or follow waypoints.
             .Sequence() // Find nearest target and either path to them or seek them directly.              
                 .Sequence(CompositeDecorator::Success)
                     .Child<PlayerPositionQueryNode>("self_position") //Always track self position
@@ -263,13 +244,13 @@ std::unique_ptr<behavior::BehaviorNode> ThreesBehavior::CreateTree(behavior::Exe
                     .Child<PlayerPositionQueryNode>("nearest_enemy", "nearest_enemy_position") //Always track nearest enemy position so we can use it for some checks
                     .Child<PlayerEnergyQueryNode>("nearest_enemy", "nearest_enemy_energy")
                     .Child<AimNode>(WeaponType::Bullet, "nearest_enemy", "nearest_aimshot")
-                    .Sequence() 
+                    .Sequence() // Default targert is nearest
                         .Child<NearestMemoryTargetNode>("target")
                         .Child<PlayerPositionQueryNode>("target", "target_position")
                         .Child<PlayerEnergyQueryNode>("target", "target_energy")
                         .Child<AimNode>(WeaponType::Bullet, "target", "aimshot")
                         .End()
-                     .Sequence() //If is someone low nearby override target instead of just using nearest
+                     .Sequence() // If is someone low nearby override target instead of just using nearest
                         .Child<TimerExpiredNode>("recharge_timer") //if we're recharging we should always be leashing to nearest enemy so ignore low health
                         .Child<LowestTargetNode>("lowest_target")
                         .Child<PlayerPositionQueryNode>("lowest_target", "lowest_target_position")
@@ -320,8 +301,7 @@ std::unique_ptr<behavior::BehaviorNode> ThreesBehavior::CreateTree(behavior::Exe
                 .Selector()
                     .Sequence() // Attempt to dodge and use defensive items.
                         .Sequence(CompositeDecorator::Success) // Always check incoming damage so we can use it in repel and portal sequences.
-                            .Child<RepelDistanceQueryNode>("repel_distance")
-                            .Child<IncomingDamageQueryNode>("repel_distance", "incoming_damage")
+                            .Child<IncomingDamageQueryNode>(kRepelDistance, "incoming_damage")
                             .Child<PlayerCurrentEnergyQueryNode>("self_energy")
                             .End()
                         .Sequence(CompositeDecorator::Success) // If we are in danger but can't repel, use our portal.
@@ -343,19 +323,20 @@ std::unique_ptr<behavior::BehaviorNode> ThreesBehavior::CreateTree(behavior::Exe
                             .InvertChild<ScalarThresholdNode<float>>("target_energy", kLowEnergyRushThreshold)
                             .InvertChild<DistanceThresholdNode>("target_position", "self_position", kRushDistanceThreshold)
                             .End()
-                        .Child<DodgeIncomingDamage>(0.25f, 45.0f) //was .3 30
-                        .End()
-                    .Sequence() //Avoid walls unless we're rushing
-                        .InvertChild<BlackboardSetQueryNode>("rushing")
-                        .InvertChild<TileQueryNode>(kTileIdSafe)
-                        .Child<SeekFromWallNode>(kAvoidWallDistance)
+                        .Sequence(CompositeDecorator::Invert)  // If we're moving fast increase dodge distance threshold
+                                .Child<PlayerVelocityQueryNode>("self_velocity")
+                                .Child<VectorDotNode>("self_velocity", "target_direction", "forward_velocity")
+                                .Child<ScalarThresholdNode<float>>("forward_velocity", kDodgeVelocityThreshold)
+                                .Child<DodgeIncomingDamage>(0.2f, kDodgeRangeFast)
+                                .End()
+                        .Child<DodgeIncomingDamage>(0.1f, kDodgeRangeSlow) //was .3 30
                         .End()
                     .Sequence()  //Keep enemy distance while reacharging, if within seek range face away from target to help dodging
                         .InvertChild<TimerExpiredNode>("recharge_timer")
-                        .Child<SeekNode>("nearest_aimshot", kLeashDistanceAttack, SeekNode::DistanceResolveType::Dynamic)  
-                        .Sequence(CompositeDecorator::Success) // Face away from target so it can dodge while waiting for bomb cooldown.
-                            .InvertChild<DistanceThresholdNode>("nearest_enemy_position", kLeashDistance + 2.0f)  //dont bomb from too far
-                            .Child<DistanceThresholdNode>("nearest_enemy_position", kLeashDistance - 2.0f)  //check to ensure no enemies are on top of us
+                        .Child<SeekNode>("nearest_aimshot", kLeashDistance, SeekNode::DistanceResolveType::Dynamic)  
+                        .Sequence(CompositeDecorator::Success) // Face away from target when at leash range
+                            .InvertChild<DistanceThresholdNode>("nearest_enemy_position", kLeashDistance + 2.0f)  
+                            .Child<DistanceThresholdNode>("nearest_enemy_position", kLeashDistance - 2.0f)  
                             .Child<PerpendicularNode>("nearest_enemy_position", "self_position", "away_dir", true)
                             .Child<VectorSubtractNode>("nearest_enemy_position", "self_position", "target_direction", true)
                             .Child<VectorAddNode>("away_dir", "target_direction", "away_dir", true)
@@ -365,7 +346,7 @@ std::unique_ptr<behavior::BehaviorNode> ThreesBehavior::CreateTree(behavior::Exe
                             .End()
                         .End()
                     .Sequence() // Path to teammate if far away
-                        .Child<NearestTeammateNode>("nearest_teammate", 2) //Make sure we have at least 1 teammate close, if more than one stay with the broader group
+                        .Child<NearestTeammateNode>("nearest_teammate", kTeamRangeMemberIndex) //Make sure we have at least 1 teammate close, if more than one stay with the broader group
                         .Child<PlayerPositionQueryNode>("nearest_teammate", "nearest_teammate_position")
                         .Child<DistanceThresholdNode>("nearest_teammate_position", kTeamRange) //If we're already near teammates dont run to them
                         .Child<ScalarThresholdNode<float>>("target_energy", kLowEnergyThreshold)  //If we're going for a kill or someone is diving dont run
@@ -374,6 +355,7 @@ std::unique_ptr<behavior::BehaviorNode> ThreesBehavior::CreateTree(behavior::Exe
                         .Child<RenderPathNode>(Vector3f(0.0f, 1.0f, 0.5f))
                         .End()
                     .Sequence() // Path to target if they aren't immediately visible.
+                        .Child<TimerExpiredNode>("match_startup")
                         .InvertChild<VisibilityQueryNode>("target_position")
                         .Child<GoToNode>("target_position")
                         .Parallel(CompositeDecorator::Success)
@@ -390,7 +372,7 @@ std::unique_ptr<behavior::BehaviorNode> ThreesBehavior::CreateTree(behavior::Exe
                             .End()
                         .Parallel()     
                             .Child<FaceNode>("aimshot")
-                            .Child<BlackboardEraseNode>("rushing")                      
+                            .Child<BlackboardEraseNode>("rushing")
                             .Selector()
                                .Sequence() // If there is any low target with in this range prioritize
                                     //.Child<ShipItemCountThresholdNode>(ShipItemType::Repel, kRushRepelThreshold) //dont rush if we have no reps
@@ -447,7 +429,6 @@ std::unique_ptr<behavior::BehaviorNode> ThreesBehavior::CreateTree(behavior::Exe
                                 .Child<RenderRayNode>("world_camera", "bomb_fire_ray", 50.0f, Vector3f(1.0f, 0.0f, 0.0f))
                                 .Child<RayRectangleInterceptNode>("bomb_fire_ray", "target_bounds")
                                 .Child<InputActionNode>(InputAction::Bomb)
-                               // .InvertChild<TimerSetNode>("recharge_timer", "20")  //add slight backoff after firing a bomb
                                 .End()
                             .Sequence(CompositeDecorator::Success) // PB thor fire check.
                                 .Child<TimerExpiredNode>("match_startup")

--- a/zero/zones/nexus/ThreesBehavior.h
+++ b/zero/zones/nexus/ThreesBehavior.h
@@ -12,8 +12,6 @@ struct ThreesBehavior : public behavior::Behavior {
   void OnInitialize(behavior::ExecuteContext& ctx) override {
     // Setup blackboard here for this specific behavior
     ctx.blackboard.Set("request_ship", 4);
-    ctx.blackboard.Set("leash_distance", 30.0f);
-    ctx.blackboard.Set("run_distance", 50.0f);
     ctx.blackboard.Set("startup_damage_trigger", "50");
 
 

--- a/zero/zones/nexus/TwosBehavior.cpp
+++ b/zero/zones/nexus/TwosBehavior.cpp
@@ -142,21 +142,22 @@ std::unique_ptr<behavior::BehaviorNode> TwosBehavior::CreateTree(behavior::Execu
 
   const Vector2f center(512, 512);
 
-  // Used for target prio
-  constexpr float kLowEnergyThreshold = 700.0f;         // Energy threshold to prio targets
-  constexpr float kLowEnergyDistanceThreshold = 20.0f;  // Distance threshold for prio targets
+ // Pursue targets below these thresholds, otherwise attack from distance
+  constexpr float kLowEnergyThreshold = 700.0f;         // Energy threshold
+  constexpr float kLowEnergyDistanceThreshold = 18.0f;  // Distance threshold
+  constexpr u32 kRushRepelThreshold = 1;  // If we don't have this many reps dont rush targets (in testing)
 
-  // Rush threshold / dodge thresholds
-  constexpr float kLowEnergyRushThreshold = 300.0f;  // If within rush distance and below this threshold
-  constexpr float kRushDistanceThreshold = 10.0f;    // If below rush energy threshold and this distance
-  constexpr u32 kRushRepelThreshold = 1;             // If we don't have this many reps dont rush targets
+  // Stop attempting to dodge when target is below these thresholds
+  constexpr float kLowEnergyRushThreshold = 300.0f;  // Energy threshold
+  constexpr float kRushDistanceThreshold = 8.0f;     // Distance threshold
 
-  // This is how far away to check for enemies that are rushing at us with low energy.
-  // We will stop dodging and try to finish them off if they are within this distance and low energy.
-  constexpr float kNearbyEnemyThreshold = 10.0f;
+  // Other dodge
+  constexpr float kDodgeVelocityThreshold = 10.0f;
+  constexpr float kDodgeRangeSlow = 20.0f;
+  constexpr float kDodgeRangeFast = 45.0f;  // When
 
-  // Check for incoming damage within this range
-  constexpr float kRepelDistance = 7.0f;
+  // Check for incoming damage within this range, if greater than current energy rep
+  constexpr float kRepelDistance = 9.0f;
 
   // How much damage that is going towards an enemy before we start bombing. This is to limit the frequency of our
   // bombing so it overlaps bullets and is harder to dodge.
@@ -165,30 +166,23 @@ std::unique_ptr<behavior::BehaviorNode> TwosBehavior::CreateTree(behavior::Execu
   // How far away a target needs to be before we start varying our shots around the target.
   constexpr float kShotSpreadDistanceThreshold = 40.0f;
 
-  //  If an enemy is near us and we're low energy thor if below this value
-  constexpr float kThorEnemyThreshold = 200.0f;
+  //  If an enemy is near us and we're low energy attempt to pb thor target
+  constexpr float kThorEnemyThreshold = 250.0f;
 
-  // How far away from a teammate before we regroup
-  constexpr float kTeamRange = 40.0f;
+  // Distance away from team before we regroup
+  constexpr float kTeamRange = 40.0f;       // Distance away from team member before we regroup
+  constexpr int kTeamRangeMemberIndex = 3;  // Use the 3rd furthest teammate as the base, otherwise the next furthest
 
-  constexpr float kLeashDistance = 30.0f;
-  constexpr float kLeashDistanceAttack = 20.0f;
+  // Leash Settings
+  constexpr float kLeashDistance = 30.0f;        // Used for low-energy retreating
+  constexpr float kLeashDistanceAttack = 20.0f;  // Used for default attack distance
 
-  constexpr float kAvoidTeamDistance = 8.0f;
-
-  constexpr float kAvoidEnemyDistance = 10.0f;
-
-  constexpr float kMultiFireDistance = 35.0f; //Use multifire for targets over this range
-
+  // Misc
+  constexpr float kAvoidTeamDistance = 8.0f;    // Check to ensure we're not all stacked
+  constexpr float kAvoidEnemyDistance = 10.0f;  // Additional check when pathing to prevent enemies from sitting on us
+  constexpr float kMultiFireDistance = 35.0f;   // Use multifire for targets over this range
   constexpr float kAvoidWallDistance = 3.0f;
-
-  //.Child<ReadConfigIntNode<u16>>("queue_command1", "command1")
-  //.Child<ReadConfigIntNode<u16>>("queue_command2", "command2")
-  //.Child<ReadConfigIntNode<u16>>("queue_command3", "command3")
-  //.Child<ChatMessageNode>(ChatMessageNode::PublicBlackboard("command1")) // Invert so this fails and freq is
-  //reevaluated. .Child<ChatMessageNode>(ChatMessageNode::PublicBlackboard("command2")) // Invert so this fails and freq
-  //is reevaluated. .Child<ChatMessageNode>(ChatMessageNode::PublicBlackboard("command3")) // Invert so this fails and
-  //freq is reevaluated.
+  
   // clang-format off
   builder
     .Selector()
@@ -242,20 +236,7 @@ std::unique_ptr<behavior::BehaviorNode> TwosBehavior::CreateTree(behavior::Execu
             .Child<AttachedQueryNode>("self")
             .Child<DetachNode>()
             .End()
-      // .Sequence()  //If player shot at us cancel startup/ready check
-           // .InvertChild<TimerExpiredNode>("match_startup")      
-          //  .Child<ScalarThresholdNode<float>>("incoming_damage", "startup_damage_trigger")
-          //  .Child<BlackboardEraseNode>("match_startup")
-          //  .End()
-//       .Sequence() // Switch to own frequency when possible.
-//            .Child<ReadConfigIntNode<u16>>("Freq", "request_freq")
-//            .Child<PlayerFrequencyQueryNode>("self_freq")
-//            .InvertChild<EqualityNode<u16>>("self_freq", "request_freq")
-//            .Child<TimerExpiredNode>("next_freq_change_tick")
-//            .Child<TimerSetNode>("next_freq_change_tick", 300)
-//            .Child<PlayerChangeFrequencyNode>("request_freq")
- //           .End()
-   .Selector() // Choose to fight the player or follow waypoints.
+        .Selector() // Choose to fight the player or follow waypoints.
             .Sequence() // Find nearest target and either path to them or seek them directly.              
                 .Sequence(CompositeDecorator::Success)
                     .Child<PlayerPositionQueryNode>("self_position") //Always track self position
@@ -263,13 +244,13 @@ std::unique_ptr<behavior::BehaviorNode> TwosBehavior::CreateTree(behavior::Execu
                     .Child<PlayerPositionQueryNode>("nearest_enemy", "nearest_enemy_position") //Always track nearest enemy position so we can use it for some checks
                     .Child<PlayerEnergyQueryNode>("nearest_enemy", "nearest_enemy_energy")
                     .Child<AimNode>(WeaponType::Bullet, "nearest_enemy", "nearest_aimshot")
-                    .Sequence() 
+                    .Sequence() // Default targert is nearest
                         .Child<NearestMemoryTargetNode>("target")
                         .Child<PlayerPositionQueryNode>("target", "target_position")
                         .Child<PlayerEnergyQueryNode>("target", "target_energy")
                         .Child<AimNode>(WeaponType::Bullet, "target", "aimshot")
                         .End()
-                     .Sequence() //If is someone low nearby override target instead of just using nearest
+                     .Sequence() // If is someone low nearby override target instead of just using nearest
                         .Child<TimerExpiredNode>("recharge_timer") //if we're recharging we should always be leashing to nearest enemy so ignore low health
                         .Child<LowestTargetNode>("lowest_target")
                         .Child<PlayerPositionQueryNode>("lowest_target", "lowest_target_position")
@@ -320,8 +301,7 @@ std::unique_ptr<behavior::BehaviorNode> TwosBehavior::CreateTree(behavior::Execu
                 .Selector()
                     .Sequence() // Attempt to dodge and use defensive items.
                         .Sequence(CompositeDecorator::Success) // Always check incoming damage so we can use it in repel and portal sequences.
-                            .Child<RepelDistanceQueryNode>("repel_distance")
-                            .Child<IncomingDamageQueryNode>("repel_distance", "incoming_damage")
+                            .Child<IncomingDamageQueryNode>(kRepelDistance, "incoming_damage")
                             .Child<PlayerCurrentEnergyQueryNode>("self_energy")
                             .End()
                         .Sequence(CompositeDecorator::Success) // If we are in danger but can't repel, use our portal.
@@ -343,14 +323,20 @@ std::unique_ptr<behavior::BehaviorNode> TwosBehavior::CreateTree(behavior::Execu
                             .InvertChild<ScalarThresholdNode<float>>("target_energy", kLowEnergyRushThreshold)
                             .InvertChild<DistanceThresholdNode>("target_position", "self_position", kRushDistanceThreshold)
                             .End()
-                        .Child<DodgeIncomingDamage>(0.25f, 45.0f) //was .3 30
+                        .Sequence(CompositeDecorator::Invert)  // If we're moving fast increase dodge distance threshold
+                                .Child<PlayerVelocityQueryNode>("self_velocity")
+                                .Child<VectorDotNode>("self_velocity", "target_direction", "forward_velocity")
+                                .Child<ScalarThresholdNode<float>>("forward_velocity", kDodgeVelocityThreshold)
+                                .Child<DodgeIncomingDamage>(0.2f, kDodgeRangeFast)
+                                .End()
+                        .Child<DodgeIncomingDamage>(0.1f, kDodgeRangeSlow) //was .3 30
                         .End()
                     .Sequence()  //Keep enemy distance while reacharging, if within seek range face away from target to help dodging
                         .InvertChild<TimerExpiredNode>("recharge_timer")
-                        .Child<SeekNode>("nearest_aimshot", kLeashDistanceAttack, SeekNode::DistanceResolveType::Dynamic)  
-                        .Sequence(CompositeDecorator::Success) // Face away from target so it can dodge while waiting for bomb cooldown.
-                            .InvertChild<DistanceThresholdNode>("nearest_enemy_position", kLeashDistance + 2.0f)  //dont bomb from too far
-                            .Child<DistanceThresholdNode>("nearest_enemy_position", kLeashDistance - 2.0f)  //check to ensure no enemies are on top of us
+                        .Child<SeekNode>("nearest_aimshot", kLeashDistance, SeekNode::DistanceResolveType::Dynamic)  
+                        .Sequence(CompositeDecorator::Success) // Face away from target when at leash range
+                            .InvertChild<DistanceThresholdNode>("nearest_enemy_position", kLeashDistance + 2.0f)  
+                            .Child<DistanceThresholdNode>("nearest_enemy_position", kLeashDistance - 2.0f)  
                             .Child<PerpendicularNode>("nearest_enemy_position", "self_position", "away_dir", true)
                             .Child<VectorSubtractNode>("nearest_enemy_position", "self_position", "target_direction", true)
                             .Child<VectorAddNode>("away_dir", "target_direction", "away_dir", true)
@@ -360,7 +346,7 @@ std::unique_ptr<behavior::BehaviorNode> TwosBehavior::CreateTree(behavior::Execu
                             .End()
                         .End()
                     .Sequence() // Path to teammate if far away
-                        .Child<NearestTeammateNode>("nearest_teammate", 2) //Make sure we have at least 1 teammate close, if more than one stay with the broader group
+                        .Child<NearestTeammateNode>("nearest_teammate", kTeamRangeMemberIndex) //Make sure we have at least 1 teammate close, if more than one stay with the broader group
                         .Child<PlayerPositionQueryNode>("nearest_teammate", "nearest_teammate_position")
                         .Child<DistanceThresholdNode>("nearest_teammate_position", kTeamRange) //If we're already near teammates dont run to them
                         .Child<ScalarThresholdNode<float>>("target_energy", kLowEnergyThreshold)  //If we're going for a kill or someone is diving dont run
@@ -369,6 +355,7 @@ std::unique_ptr<behavior::BehaviorNode> TwosBehavior::CreateTree(behavior::Execu
                         .Child<RenderPathNode>(Vector3f(0.0f, 1.0f, 0.5f))
                         .End()
                     .Sequence() // Path to target if they aren't immediately visible.
+                        .Child<TimerExpiredNode>("match_startup")
                         .InvertChild<VisibilityQueryNode>("target_position")
                         .Child<GoToNode>("target_position")
                         .Parallel(CompositeDecorator::Success)
@@ -385,7 +372,7 @@ std::unique_ptr<behavior::BehaviorNode> TwosBehavior::CreateTree(behavior::Execu
                             .End()
                         .Parallel()     
                             .Child<FaceNode>("aimshot")
-                            .Child<BlackboardEraseNode>("rushing")                      
+                            .Child<BlackboardEraseNode>("rushing")
                             .Selector()
                                .Sequence() // If there is any low target with in this range prioritize
                                     //.Child<ShipItemCountThresholdNode>(ShipItemType::Repel, kRushRepelThreshold) //dont rush if we have no reps
@@ -442,7 +429,6 @@ std::unique_ptr<behavior::BehaviorNode> TwosBehavior::CreateTree(behavior::Execu
                                 .Child<RenderRayNode>("world_camera", "bomb_fire_ray", 50.0f, Vector3f(1.0f, 0.0f, 0.0f))
                                 .Child<RayRectangleInterceptNode>("bomb_fire_ray", "target_bounds")
                                 .Child<InputActionNode>(InputAction::Bomb)
-                               // .InvertChild<TimerSetNode>("recharge_timer", "20")  //add slight backoff after firing a bomb
                                 .End()
                             .Sequence(CompositeDecorator::Success) // PB thor fire check.
                                 .Child<TimerExpiredNode>("match_startup")

--- a/zero/zones/nexus/TwosBehavior.cpp
+++ b/zero/zones/nexus/TwosBehavior.cpp
@@ -156,7 +156,7 @@ std::unique_ptr<behavior::BehaviorNode> TwosBehavior::CreateTree(behavior::Execu
   constexpr float kNearbyEnemyThreshold = 10.0f;
 
   // Check for incoming damage within this range
-  constexpr float kRepelDistance = 10.0f;
+  constexpr float kRepelDistance = 8.0f;
 
   // How much damage that is going towards an enemy before we start bombing. This is to limit the frequency of our
   // bombing so it overlaps bullets and is harder to dodge.

--- a/zero/zones/nexus/TwosBehavior.cpp
+++ b/zero/zones/nexus/TwosBehavior.cpp
@@ -156,7 +156,7 @@ std::unique_ptr<behavior::BehaviorNode> TwosBehavior::CreateTree(behavior::Execu
   constexpr float kNearbyEnemyThreshold = 10.0f;
 
   // Check for incoming damage within this range
-  constexpr float kRepelDistance = 8.0f;
+  constexpr float kRepelDistance = 7.0f;
 
   // How much damage that is going towards an enemy before we start bombing. This is to limit the frequency of our
   // bombing so it overlaps bullets and is harder to dodge.

--- a/zero/zones/nexus/TwosBehavior.h
+++ b/zero/zones/nexus/TwosBehavior.h
@@ -12,9 +12,7 @@ struct TwosBehavior : public behavior::Behavior {
   void OnInitialize(behavior::ExecuteContext& ctx) override {
     // Setup blackboard here for this specific behavior
     ctx.blackboard.Set("request_ship", 4);
-    ctx.blackboard.Set("run_distance", 50.0f);
     ctx.blackboard.Set("startup_damage_trigger", "50");
-
 
     std::vector<Vector2f> waypoints{
         Vector2f(410, 415), Vector2f(615, 395), Vector2f(515, 545), Vector2f(505, 680), Vector2f(355, 545),

--- a/zero/zones/nexus/TwosBoxBehavior.cpp
+++ b/zero/zones/nexus/TwosBoxBehavior.cpp
@@ -118,7 +118,7 @@ std::unique_ptr<behavior::BehaviorNode> TwosBoxBehavior::CreateTree(behavior::Ex
   constexpr float kNearbyEnemyThreshold = 15.0f;
 
   // Check for incoming damage within this range
-  constexpr float kRepelDistance = 8.0f;
+  constexpr float kRepelDistance = 7.0f;
 
   // How much damage that is going towards an enemy before we start bombing. This is to limit the frequency of our
   // bombing so it overlaps bullets and is harder to dodge.

--- a/zero/zones/nexus/TwosBoxBehavior.cpp
+++ b/zero/zones/nexus/TwosBoxBehavior.cpp
@@ -118,7 +118,7 @@ std::unique_ptr<behavior::BehaviorNode> TwosBoxBehavior::CreateTree(behavior::Ex
   constexpr float kNearbyEnemyThreshold = 15.0f;
 
   // Check for incoming damage within this range
-  constexpr float kRepelDistance = 15.0f;
+  constexpr float kRepelDistance = 8.0f;
 
   // How much damage that is going towards an enemy before we start bombing. This is to limit the frequency of our
   // bombing so it overlaps bullets and is harder to dodge.


### PR DESCRIPTION
*Lower incoming damage distance threshold to try and improve early/wasted reps when there is still an opportunity to dodge.
*Add variable incoming damage based on velocity to help reduce instances of full speed collisions but reduce distance at lower velocities where we often get stuck when a weapon is moving with slow velocity that is roughly the same as ours.
*Standardize vars across behaviors, fix incorrect recharge leash distance.
